### PR TITLE
Allow filtering by two or more types in locations.json

### DIFF
--- a/api/locations.js
+++ b/api/locations.js
@@ -191,8 +191,8 @@ locations.list = function (req, res) {
       return parseInt(x)
     });
 
-    sorted = "CASE WHEN array_agg(t.id) @> ARRAY["
-      + tids + "] THEN 0 ELSE 1 END as sort";
+    sorted = "CASE WHEN l.type_ids && ARRAY["+ tids.join(', ') + "] THEN 0 " +
+      "ELSE 1 END as sort";
   }
 
   var limit = req.query.limit ?


### PR DESCRIPTION
@ezwelty 

This uses the array overlap (&&) operator in PostgreSQL to achieve this. See:

https://www.postgresql.org/docs/9.1/static/functions-array.html

This should be more like what you want, and preserves the original `sort` flag and value. Sorry for the confusion.

Closes #14