### PR TITLE
Return title from locations.show/list

### DIFF
--- a/api/locations.js
+++ b/api/locations.js
@@ -1,5 +1,19 @@
 var locations = {};
 
+function addTitleToLocation(location) {
+  if (location.type_names) {
+    var names = location.type_names.slice(0, 2);
+
+    if (location.type_names.length > 2) {
+      names.push("...");
+    }
+
+    location.title = names.join(', ');
+  }
+
+  return location;
+}
+
 locations.add = function (req, res) {
   db.pg.connect(db.conString, function(err, client, done) {
     if (err){ 
@@ -289,6 +303,8 @@ locations.list = function (req, res) {
                 x.photo_file_name = parts[0];
               }
 
+              x = addTitleToLocation(x);
+
               return x;
             })
           );
@@ -368,6 +384,8 @@ locations.show = function (req, res) {
               x.photo = common.photo_urls(x.id, x.photo_file_name);
               return x;
             });
+
+            x = addTitleToLocation(x);
 
             res.send(location);
           });

--- a/api/locations.js
+++ b/api/locations.js
@@ -372,6 +372,7 @@ locations.show = function (req, res) {
 
           location = result.rows[0];
           location.num_reviews = parseInt(location.num_reviews);
+          location = addTitleToLocation(location);
 
           var photoQuery = "SELECT id, photo_updated_at, photo_file_name \
             FROM observations \
@@ -384,8 +385,6 @@ locations.show = function (req, res) {
               x.photo = common.photo_urls(x.id, x.photo_file_name);
               return x;
             });
-
-            x = addTitleToLocation(x);
 
             res.send(location);
           });


### PR DESCRIPTION
@ezwelty This adds a `title` column to the response for `locations.show` and `locations.list`.

This is the API side of the work for #17.

I'm curious what UI elements need to get updated on the client-side to reflect this new title field? Could you point me in the right direction w/ a few screenshots? Or if it's faster for you to make the new edits, open a PR against the `new-api` branch in `falling-fruit-mobile`?

Thanks!