### PR TITLE
Update add locations api to work with post bodies

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -12,6 +12,10 @@ var router = express.Router();
 //var apicache = require('apicache').options({ debug: true }).middleware;
 var multer = require('multer');
 var app = express();
+var bodyParser = require('body-parser');
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(multer({ dest: config.temp_dir }));
 

--- a/api/package.json
+++ b/api/package.json
@@ -15,19 +15,20 @@
   ],
   "license": "GNU GPL 3.0",
   "dependencies": {
-    "express": "== 4.13.0",
-    "pg": "== 4.4.0",
-    "js-yaml": "== 3.3.1",
-    "async": "== 1.2.1",
-    "underscore": "== 1.8.3",
-    "underscore.string": "== 3.1.1",
     "apicache": "== 0.0.12",
+    "async": "== 1.2.1",
     "bcrypt-nodejs": "== 0.0.3",
+    "body-parser": "^1.17.1",
+    "express": "== 4.13.0",
     "gm": "== 1.18.1",
-    "s3": "== 4.4.0",
-    "multer": "== 0.1.8",
     "hat": "== 0.0.3",
-    "pm2": "== 0.14.3"
+    "js-yaml": "== 3.3.1",
+    "multer": "== 0.1.8",
+    "pg": "== 4.4.0",
+    "pm2": "== 0.14.3",
+    "s3": "== 4.4.0",
+    "underscore": "== 1.8.3",
+    "underscore.string": "== 3.1.1"
   },
   "bin": {
     "api": "./app.js"


### PR DESCRIPTION
This updates the API to enable saving new locations https://github.com/falling-fruit/falling-fruit-mobile/issues/11

I'm concerned with this API location creation route expecting way more fields than the actual mobile UI provides to fill out.

Here are the extra fields by database table that get read from `post.body` even though the form doesn't actually submit them:

*locations*

* unverified
* season_start
* season_stop
* no_season

*observations*

* author
* comment
* photo_file_name
* observed_on

In general we shouldn't expect data server-side we aren't going to get submitted to us – that's just confusing. Is there another view somewhere, perhaps on the desktop version of the site, that includes these fields that would be submitted to `locations.add`?
