### PR TITLE
Remove Gratipay link

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -25,11 +25,6 @@
 
   &nbsp; &middot; &nbsp;
 
-  <!-- Gratipay  -->
-  <form action="https://gratipay.com/falling-fruit/" style="display:inline;">
-    <button type="submit" style="padding:0.25em 0.4em;"><%= translate("pages.about.give_gratipay") %></button>
-  </form>
-
   </blockquote>
 
 <p class="announcement"><b><%= translate("pages.about.write") %></b>


### PR DESCRIPTION
I simply deleted the area under the <! Gratipay> link up until the </blockquote>, which now I believe only includes the PayPal.  I altered nothing else, but if there are other lines to be deleted feel free to delete them.