### PR TITLE
Replace Sendgrid categories with Postmark tags

### DIFF
--- a/app/mailers/devise_custom.rb
+++ b/app/mailers/devise_custom.rb
@@ -4,7 +4,7 @@ class DeviseCustom < Devise::Mailer
   # default template_path: 'devise_cusom'
 
   def confirmation_instructions(record)
-    headers['X-SMTPAPI'] = '{"category": "FF-Rails-DeviseConfirmation"}'
+    headers['X-PM-Tag'] = 'email-confirmation'
     super
   end
 end

--- a/app/mailers/spammer.rb
+++ b/app/mailers/spammer.rb
@@ -3,14 +3,14 @@ class Spammer < ActionMailer::Base
 
   def range_changes(user, ndays)
     return nil if user.nil?
-    headers['X-SMTPAPI'] = '{"category": "FF-Rails-RangeUpdate"}'
+    headers['X-PM-Tag'] = 'range-update'
     @changes = Change.where("changes.created_at > NOW() - interval '? days' AND ST_INTERSECTS((SELECT range FROM users WHERE id=?),location)",ndays,user.id).joins(:location)
     @user = user
     return ((@changes.length == 0) ? nil : mail(:to => user.email, :subject => "Falling Fruit - Range Update"))
   end
 
   def respond_to_problem(problem)
-    headers['X-SMTPAPI'] = '{"category": "FF-Rails-ProblemResponse"}'
+    headers['X-PM-Tag'] = 'problem-response'
     unless problem.resolution_code.nil?
       @problem = problem
       unless problem.reporter.nil?


### PR DESCRIPTION
Having switched from Sendgrid to Postmark, this updates SMTP email headers so that Postmark correctly tags emails by type. Follows the instructions given here: https://postmarkapp.com/developer/user-guide/send-email-with-smtp.